### PR TITLE
No arguments limit + Remove autoload when deactivating plugin + Some refinements

### DIFF
--- a/addons/console/Console.gd
+++ b/addons/console/Console.gd
@@ -99,11 +99,13 @@ func _input(event : InputEvent) -> void:
 						reset_autocomplete()
 			if (event.get_physical_keycode_with_modifiers() == KEY_PAGEUP):
 				var scroll := rich_label.get_v_scroll_bar()
-				scroll.value -= scroll.page - scroll.page * 0.1
+				var tween := create_tween()
+				tween.tween_property(scroll, "value",  scroll.value - (scroll.page - scroll.page * 0.1), 0.1)
 				get_tree().get_root().set_input_as_handled()
 			if (event.get_physical_keycode_with_modifiers() == KEY_PAGEDOWN):
 				var scroll := rich_label.get_v_scroll_bar()
-				scroll.value += scroll.page - scroll.page * 0.1
+				var tween := create_tween()
+				tween.tween_property(scroll, "value",  scroll.value + (scroll.page - scroll.page * 0.1), 0.1)
 				get_tree().get_root().set_input_as_handled()
 			if (event.get_physical_keycode_with_modifiers() == KEY_TAB):
 				autocomplete()

--- a/addons/console/Console.gd
+++ b/addons/console/Console.gd
@@ -241,7 +241,6 @@ func help() -> void:
 		[color=light_green]clear[/color]: Clears the registry view
 		[color=light_green]commands_list[/color]: Shows a list of all the currently registered commands
 		[color=light_green]delete_hystory[/color]: Deletes the commands history
-		[color=light_green]code_example[/color]: Shows an usage example
 		[color=light_green]quit[/color]: Quits the game
 	Controls:
 		[color=light_blue]Up[/color] and [color=light_blue]Down[/color] arrow keys to navigate commands history

--- a/addons/console/Console.gd
+++ b/addons/console/Console.gd
@@ -30,15 +30,19 @@ func _ready() -> void:
 	control.anchor_bottom = 1.0
 	control.anchor_right = 1.0
 	canvas_layer.add_child(control)
+	var style := StyleBoxFlat.new()
+	style.bg_color = Color("000000d7")
+	rich_label.bbcode_enabled = true
 	rich_label.scroll_following = true
 	rich_label.anchor_right = 1.0
 	rich_label.anchor_bottom = 0.5
-	rich_label.add_theme_stylebox_override("normal", load("res://addons/console/console_background.tres"))
+	rich_label.add_theme_stylebox_override("normal", style)
 	control.add_child(rich_label)
-	rich_label.text = "Development console.\n"
+	rich_label.append_text("Development console.\n")
 	line_edit.anchor_top = 0.5
 	line_edit.anchor_right = 1.0
 	line_edit.anchor_bottom = 0.5
+	line_edit.placeholder_text = "Enter \"help\" for instructions"
 	control.add_child(line_edit)
 	line_edit.text_submitted.connect(on_text_entered)
 	line_edit.text_changed.connect(on_line_edit_text_changed)
@@ -174,8 +178,8 @@ func print_line(text : String) -> void:
 	if (!rich_label): # Tried to print something before the console was loaded.
 		call_deferred("print_line", text)
 	else:
-		rich_label.add_text(text)
-		rich_label.add_text("\n")
+		rich_label.append_text(text)
+		rich_label.append_text("\n")
 
 
 func on_text_entered(text : String) -> void:
@@ -232,20 +236,20 @@ func delete_history() -> void:
 
 
 func help() -> void:
-	rich_label.add_text("\
-	\n\
-	Built in commands:\n\
-		'clear' : Clears the current registry view\n\
-		'commands_list': Shows a list of all the currently registered commands\n\
-		'delete_hystory' : Deletes the commands history\n\
-		'quit' : Quits the game\n\
-	Controls:\n\
-		Up and Down arrow keys to navigate commands history\n\
-		PageUp and PageDown to navigate registry history\n\
-		Ctr+Tilde to change console size between half screen and full creen\n\
-		Tilde or Esc to close the console\n\
-		Tab for basic autocomplete\n\
-	\n")
+	rich_label.append_text("
+	Built in commands:
+		[color=light_green]clear[/color]: Clears the registry view
+		[color=light_green]commands_list[/color]: Shows a list of all the currently registered commands
+		[color=light_green]delete_hystory[/color]: Deletes the commands history
+		[color=light_green]code_example[/color]: Shows an usage example
+		[color=light_green]quit[/color]: Quits the game
+	Controls:
+		[color=light_blue]Up[/color] and [color=light_blue]Down[/color] arrow keys to navigate commands history
+		[color=light_blue]PageUp[/color] and [color=light_blue]PageDown[/color] to scroll registry
+		[[color=light_blue]Ctr[/color] + [color=light_blue]~[/color]] to change console size between half screen and full screen
+		[color=light_blue]~[/color] or [color=light_blue]Esc[/color] key to close the console
+		[color=light_blue]Tab[/color] key to autocomplete, [color=light_blue]Tab[/color] again to cycle between matching suggestions
+	")
 
 
 func commands_list() -> void:
@@ -253,7 +257,7 @@ func commands_list() -> void:
 	for command in console_commands:
 		commands.append(str(command))
 	commands.sort()
-	rich_label.add_text(str(commands) + "\n\n")
+	rich_label.append_text(str(commands) + "\n\n")
 
 
 func add_input_history(text : String) -> void:

--- a/addons/console/Console.gd
+++ b/addons/console/Console.gd
@@ -34,6 +34,8 @@ func _ready() -> void:
 	canvas_layer.add_child(control)
 	var style := StyleBoxFlat.new()
 	style.bg_color = Color("000000d7")
+	rich_label.selection_enabled = true
+	rich_label.context_menu_enabled = true
 	rich_label.bbcode_enabled = true
 	rich_label.scroll_following = true
 	rich_label.anchor_right = 1.0
@@ -194,7 +196,7 @@ func on_text_entered(new_text : String) -> void:
 	
 	if not new_text.strip_edges().is_empty():
 		add_input_history(new_text)
-		print_line(new_text)
+		print_line("[i]> " + new_text + "[/i]")
 		var new_text_stripped := new_text.strip_edges()
 		
 		var text_split := new_text_stripped.split(" ")
@@ -248,8 +250,7 @@ func delete_history() -> void:
 
 
 func help() -> void:
-	rich_label.append_text("
-	Built in commands:
+	rich_label.append_text("	Built in commands:
 		[color=light_green]clear[/color]: Clears the registry view
 		[color=light_green]commands[/color]: Shows a list of all the currently registered commands
 		[color=light_green]commands_list[/color]: Shows a detailed list of all the currently registered commands
@@ -268,6 +269,7 @@ func commands() -> void:
 	for command in console_commands:
 		commands.append(str(command))
 	commands.sort()
+	rich_label.append_text("	")
 	rich_label.append_text(str(commands) + "\n\n")
 
 

--- a/addons/console/console_background.tres
+++ b/addons/console/console_background.tres
@@ -1,4 +1,0 @@
-[gd_resource type="StyleBoxFlat" format=2]
-
-[resource]
-bg_color = Color( 0, 0, 0, 0.843137 )

--- a/addons/console/console_plugin.gd
+++ b/addons/console/console_plugin.gd
@@ -5,3 +5,8 @@ extends EditorPlugin
 func _enter_tree():
 	print("Console plugin activated.")
 	add_autoload_singleton("Console", "res://addons/console/Console.gd")
+
+
+func _exit_tree():
+	print ("Console plugin exited.")
+	remove_autoload_singleton("Console")

--- a/addons/console/plugin.cfg
+++ b/addons/console/plugin.cfg
@@ -1,6 +1,6 @@
 [plugin]
 
-name="Console"
+name="Developer Console"
 description="Developer console.	  Press ~ to activate it in game and execute commands."
 author="jitspoe"
 version="1.0"


### PR DESCRIPTION
## This is a big one
- Wen deactivating the plugin the autoload for the console was never removed, so the console still worked.
- Placeholder help text (since this is now in the AssetLib some guidance for news users is nice).
![Captura de pantalla 2023-09-16 123839](https://github.com/jitspoe/godot-console/assets/27329423/2621a6f2-989c-4813-ab37-0f63a263437e)
- No more need for a style file, the style is created inside the script.
- Correct plugin name.
- Some help text tweaks with bbcode.
- append_text() required to not break bbcode.
- New system to call commands without an arguments number limit using arrays
The only parameters required are 'command_name' and 'command_func', the rest are optional
```gdscript
add_command("command_name", command_func, ["arg_1", "arg_2", ..., "arg_n"], required_args, "Command description")
```
- Compatible with old add_command() calls using the parameter number, no need to change the old calls on your code.
- commands_list now shows an extended commands list, with arguments (required are blue) and descriptions if any.
Even old commands using arguments number can specify requirements and descriptions if desired (but not argument names)
![Captura de pantalla 2023-09-17 074728](https://github.com/jitspoe/godot-console/assets/27329423/4b6ef7bd-0e7b-4ea5-ab12-3fe3f2517cac)

- For the old commands_list functionality call commands
- Smooth scrolling
- Selection of text and contextual menu enabled (handy if the mouse is not captured)
![Captura de pantalla 2023-09-17 075954](https://github.com/jitspoe/godot-console/assets/27329423/614b03d2-468f-4d64-9a2b-d7f98a32a316)

Some code inspiration https://github.com/Calinou/godot-console-prototype