### PR TITLE
Provide an option to not pause the tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,12 @@ func param_test_function(param1 : String):
 
 The "quit"/"exit" command is implemented by default.
 
+By default the console pauses the tree (to give the user time to enter commands). If this is undesirable behaviour to you, you can change that behaviour by setting the `pause_enabled` variable accordingly.
+
+```gdscript
+func _ready_():
+  Console.pause_enabled = false
+  # Console will now NOT pause the tree when being opened
+```
+
 If you prefer to use C#, you might want to check out the C# console by Moliko here: https://github.com/MolikoDeveloper/Csharp-Console-Godot

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ func param_test_function(param1 : String):
 
 The "quit"/"exit" command is implemented by default.
 
-By default the console pauses the tree (to give the user time to enter commands). If this is undesirable behaviour to you, you can change that behaviour by setting the `pause_enabled` variable accordingly.
+By default the console does not pause the tree. If this is undesirable behaviour to you, you can change that behaviour by setting the `pause_enabled` variable accordingly.
 
 ```gdscript
 func _ready_():
-  Console.pause_enabled = false
-  # Console will now NOT pause the tree when being opened
+  Console.pause_enabled = true
+  # Console will now pause the tree when being opened
 ```
 
 If you prefer to use C#, you might want to check out the C# console by Moliko here: https://github.com/MolikoDeveloper/Csharp-Console-Godot

--- a/addons/console/Console.gd
+++ b/addons/console/Console.gd
@@ -177,7 +177,8 @@ func toggle_console() -> void:
 		control.anchor_bottom = 1.0
 		scroll_to_bottom()
 		reset_autocomplete()
-		get_tree().paused = was_paused_already
+		if (pause_enabled && !was_paused_already):
+			get_tree().paused = false
 		emit_signal("console_closed")
 
 

--- a/addons/console/Console.gd
+++ b/addons/console/Console.gd
@@ -26,7 +26,8 @@ var console_commands := {}
 var console_history := []
 var console_history_index := 0
 
-var pause_enabled: bool = true
+var pause_enabled: bool = false
+var was_paused_already: bool = false
 
 func _ready() -> void:
 	var canvas_layer := CanvasLayer.new()
@@ -168,14 +169,15 @@ func toggle_size() -> void:
 func toggle_console() -> void:
 	control.visible = !control.visible
 	if (control.visible):
-		get_tree().paused = pause_enabled
+		was_paused_already = get_tree().paused
+		get_tree().paused = was_paused_already or pause_enabled
 		line_edit.grab_focus()
 		emit_signal("console_opened")
 	else:
 		control.anchor_bottom = 1.0
 		scroll_to_bottom()
 		reset_autocomplete()
-		get_tree().paused = false
+		get_tree().paused = was_paused_already
 		emit_signal("console_closed")
 
 

--- a/addons/console/Console.gd
+++ b/addons/console/Console.gd
@@ -26,6 +26,7 @@ var console_commands := {}
 var console_history := []
 var console_history_index := 0
 
+var pause_enabled: bool = true
 
 func _ready() -> void:
 	var canvas_layer := CanvasLayer.new()
@@ -164,11 +165,10 @@ func toggle_size() -> void:
 	else:
 		control.anchor_bottom = 1.0
 
-
 func toggle_console() -> void:
 	control.visible = !control.visible
 	if (control.visible):
-		get_tree().paused = true
+		get_tree().paused = pause_enabled
 		line_edit.grab_focus()
 		emit_signal("console_opened")
 	else:


### PR DESCRIPTION
As mentioned in #9.

Default behaviour is still to pause the tree. This was the most straight forward way of implementing this functionality imho. 

Another would be to provide an optional shortcut for the console (like Alt+^) to bypass the tree pause. Don't know if this would be desired though.

If a pause feature is not desired in general, please just close the pull request :). Cheers!