### PR TITLE
Add a print_error() function

### DIFF
--- a/addons/console/console.gd
+++ b/addons/console/console.gd
@@ -206,6 +206,9 @@ func scroll_to_bottom() -> void:
 	var scroll: ScrollBar = rich_label.get_v_scroll_bar()
 	scroll.value = scroll.max_value - scroll.page
 
+func print_error(text : String, print_godot := false) -> void:
+	print_line("[color=light_coral]	   ERROR:[/color] %s" % text, print_godot)
+
 
 func print_line(text : String, print_godot := false) -> void:
 	if (!rich_label): # Tried to print something before the console was loaded.
@@ -277,10 +280,10 @@ func on_text_entered(new_text : String) -> void:
 				return
 			
 			if arguments.size() < console_commands[text_command].required:
-				print_line("[color=light_coral]	ERROR:[/color] Too few arguments! Required < %d >" % console_commands[text_command].required)
+				print_error("Too few arguments! Required < %d >" % console_commands[text_command].required)
 				return
 			elif arguments.size() > console_commands[text_command].arguments.size():
-				print_line("[color=light_coral]	ERROR:[/color] Too many arguments! < %d > Max" % console_commands[text_command].arguments.size())
+				print_error("Too many arguments! < %d > Max" % console_commands[text_command].arguments.size())
 				return
 
 			# Functions fail to call if passed the incorrect number of arguments, so fill out with blank strings.
@@ -290,7 +293,7 @@ func on_text_entered(new_text : String) -> void:
 			console_commands[text_command].function.callv(arguments)
 		else:
 			console_unknown_command.emit(text_command)
-			print_line("[color=light_coral]	ERROR:[/color] Command not found.")
+			print_error("Command not found.")
 
 
 func on_line_edit_text_changed(new_text : String) -> void:
@@ -351,13 +354,13 @@ func calculate(command : String) -> void:
 	var expression := Expression.new()
 	var error = expression.parse(command)
 	if error:
-		print_line("[color=light_coral]	ERROR: [/color] %s" % expression.get_error_text())
+		print_error("%s" % expression.get_error_text())
 		return
 	var result = expression.execute()
 	if not expression.has_execute_failed():
 		print_line(str(result))
 	else:
-		print_line("[color=light_coral]	ERROR: [/color] %s" % expression.get_error_text())
+		print_error("%s" % expression.get_error_text())
 
 
 func commands() -> void:


### PR DESCRIPTION
This PR is to share a little tweak I found useful in my project. It adds `print_error` which acts as a wrapper around print_line() to format error messages consistently, both for internal error messages (e.g. to avoid inconsistencies in spacing like `ERROR: [/color] %s` for some vs `ERROR:[/color] %s` for others) and for the user, who might want to validate command arguments or report command failures throughout their project and print standardized error messages:

![image](https://github.com/user-attachments/assets/6710f727-645c-4bf1-a3fc-aa28e513c7b1)
