### PR TITLE
Allow print_error and print_line to Variant text input types

### DIFF
--- a/addons/console/console.gd
+++ b/addons/console/console.gd
@@ -269,11 +269,15 @@ func scroll_to_bottom() -> void:
 	scroll.value = scroll.max_value - scroll.page
 
 
-func print_error(text : String, print_godot := false) -> void:
+func print_error(text : Variant, print_godot := false) -> void:
+	if not text is String:
+		text = str(text)
 	print_line("[color=light_coral]	   ERROR:[/color] %s" % text, print_godot)
 
 
-func print_line(text : String, print_godot := false) -> void:
+func print_line(text : Variant, print_godot := false) -> void:
+	if not text is String:
+		text = str(text)
 	if (!rich_label): # Tried to print something before the console was loaded.
 		call_deferred("print_line", text)
 	else:


### PR DESCRIPTION
Personally I quite often end up printing other data types, such as vector2's and vector3's