### PR TITLE
Add configurable canvas_layer via ProjectSetting

### DIFF
--- a/addons/console/console.gd
+++ b/addons/console/console.gd
@@ -117,7 +117,7 @@ func _enter_tree() -> void:
 		for i in range(ProjectSettings.get_setting(CONSOLE_TABSTOP)):
 			tab_string += " "
 
-	canvas_layer.layer = 3
+	canvas_layer.layer = ProjectSettings.get_setting(&"console/canvas_layer", 3)
 	add_child(canvas_layer)
 	console_scale = _get_console_scale_setting()
 	v_box_container.offset_bottom = 0

--- a/addons/console/console_plugin.gd
+++ b/addons/console/console_plugin.gd
@@ -10,6 +10,7 @@ const CONSOLE_COLOR_ERROR : String = &"console/color_error"
 const CONSOLE_COLOR_INFO : String = &"console/color_info"
 const CONSOLE_COLOR_LITERAL : String = &"console/color_literal"
 const CONSOLE_TABSTOP : String = &"console/tabstop"
+const CONSOLE_CANVAS_LAYER : String = &"console/canvas_layer"
 
 ##FIXME: This is here because project settings do no return the default value naturally
 ##This should be fixed in 4.5
@@ -59,6 +60,12 @@ func _setup_project_settings() -> void:
 		"hint": PROPERTY_HINT_RANGE,
 		"hint_string": "0,8,1,or_greater"
 	},4)
+
+	## Configure Canvas Layer
+	add_setting(CONSOLE_CANVAS_LAYER, {
+		"name": CONSOLE_CANVAS_LAYER,
+		"type": TYPE_INT,
+	}, 3)
 
 	#Configure Colors
 	add_setting(CONSOLE_COLOR_ERROR, {


### PR DESCRIPTION
The console CanvasLayer is hard-coded to layer 3, which can end up behind game UI on higher layers. This adds a console/canvas_layer ProjectSetting (default 3) so projects can control the draw order.

This would address an issue I opened up over on https://github.com/jitspoe/godot-console/issues/49 . I found it helpful in my project. Hopefully it helps someone else!