### PR TITLE
Dont make unnecessary changes to project config on startup and shutdown

### DIFF
--- a/addons/console/console_plugin.gd
+++ b/addons/console/console_plugin.gd
@@ -1,6 +1,8 @@
 @tool
 extends EditorPlugin
 
+const SINGLETON_NAME = &"Console"
+
 ##FIXME: These should be maintained in one place.
 const CONSOLE_THEME : String = &"console/theme"
 const CONSOLE_SCALE : String = &"console/scale"
@@ -95,9 +97,11 @@ func _setup_project_settings() -> void:
 	ProjectSettings.save()
 
 func _enter_tree() -> void:
-	add_autoload_singleton("Console", "res://addons/console/console.gd")
+	if not ProjectSettings.has_setting("autoload/" + SINGLETON_NAME):
+		add_autoload_singleton(SINGLETON_NAME, "res://addons/console/console.gd")
+
 	_setup_project_settings()
 	print("Console plugin activated.")
 
-func _exit_tree() -> void:
-	remove_autoload_singleton("Console")
+func _disable_plugin() -> void:
+	remove_autoload_singleton(SINGLETON_NAME)


### PR DESCRIPTION
A small addition to prevent unnecessary changes to the project at startup and shutdown.

This was something I didn't even notice until it was pointed out that one of my addons was doing the same thing.

Testing a [pull request](https://github.com/MauriceButler/godot-layer-name-enums/pull/12) to fix this for my addon, I noticed Developer Console was doing it too. 

So credit to @henpemaz for the original fix.