### PR TITLE
Added an option to add autocomplete to more than one parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,23 @@ func load_level(map_name : String):
 		add_child(level_instance)
 ```
 
-Currently, parameter autocomplete only supports 1 parameter.
+To add autocomplete for multiple parameters, call `Console.add_command_autocomplete_list(...)` multiple times with the `param_index` parameter set. Note, that the parameter index starts at 1, meaning the first parameter has the index 1 the second the index 2 and so on.
+
+```gdscript
+func _ready() -> void:
+	Console.add_command("set_arrow", command_set_arrow, ["direction", "color"], 2)
+
+	# autocomplete for "direction"
+	Console.add_command_autocomplete_list("set_arrow", ["up", "down", "left", "right"], 1)
+
+	# autocomplete for "color"
+	Console.add_command_autocomplete_list("set_arrow", ["red", "yellow", "green", "blue"], 2)
+	
+func command_set_arrow(direction: String, color: String) -> void:
+	...
+```
+
+## C#
 
 If you prefer to use C#, you might want to check out the C# console by Moliko here, but it's not currently being maintained: https://github.com/MolikoDeveloper/Csharp-Console-Godot
 

--- a/addons/console/console.gd
+++ b/addons/console/console.gd
@@ -94,6 +94,8 @@ var console_commands : Dictionary[String, ConsoleCommand] = {}
 var console_cvars : Dictionary[String, ConsoleCvar] = {}
 # Pending values are applied when cvars are registered (if loaded from config)
 var _pending_cvar_values : Dictionary[String, Variant] = {}
+# The key consists of the command name followed by a colon followed by the parameter index (starting at 1)
+# e.g.: "change_map:1" and "change_map:2"
 var command_parameters : Dictionary[String, PackedStringArray] = {}
 var console_history : Array[String] = []
 var console_history_index : int = 0
@@ -128,7 +130,9 @@ func add_hidden_command(command_name : String, function : Callable, arguments = 
 ## if you have console commands for things that are unloaded before the project closes.
 func remove_command(command_name : String) -> void:
 	console_commands.erase(command_name)
-	command_parameters.erase(command_name)
+	for key in command_parameters.keys():
+		if key.begins_with(command_name + ":"):
+			command_parameters.erase(key)
 
 
 ## Registers an auto-managed cvar that stores its value internally.
@@ -248,8 +252,8 @@ func _handle_cvar(cvar : ConsoleCvar, arguments : PackedStringArray) -> void:
 
 
 ## Useful if you have a list of possible parameters (ex: level names).
-func add_command_autocomplete_list(command_name : String, param_list : PackedStringArray):
-	command_parameters[command_name] = param_list
+func add_command_autocomplete_list(command_name : String, param_list : PackedStringArray, param_index: int = 1):
+	command_parameters["%s:%s"%[command_name,param_index]] = param_list
 
 
 func _enter_tree() -> void:
@@ -484,12 +488,15 @@ func autocomplete() -> void:
 		if (" " in line_edit.text): # We're searching for a parameter to autocomplete
 			var split_text := parse_line_input(line_edit.text)
 			if (split_text.size() > 1):
+				var param_index := split_text.size() - 1
 				var command := split_text[0]
-				var param_input := split_text[1]
-				if (command_parameters.has(command)):
-					for param in command_parameters[command]:
+				var param_input := split_text[param_index]
+				var command_with_index := "%s:%s"%[command,param_index]
+				if (command_parameters.has(command_with_index)):
+					var ready_text := " ".join(split_text.slice(0,-1))
+					for param in command_parameters[command_with_index]:
 						if (param_input in param) or (param_input.length() == 0):
-							suggestions.append(str(command, " ", param))
+							suggestions.append(str(ready_text, " ", param))
 		else:
 			var sorted_commands := []
 			for command in console_commands:
@@ -523,12 +530,12 @@ func toggle_size() -> void:
 	v_box_container.anchor_bottom = _get_console_height()
 
 
-func disable():
+func disable() -> void:
 	enabled = false
 	toggle_console() # Ensure hidden if opened
 
 
-func enable():
+func enable() -> void:
 	enabled = true
 
 
@@ -554,7 +561,7 @@ func toggle_console() -> void:
 			console_closed.emit()
 
 
-func is_visible():
+func is_visible() -> bool:
 	return v_box_container.visible
 
 

--- a/addons/console/cs_bindings/Console.cs
+++ b/addons/console/cs_bindings/Console.cs
@@ -33,11 +33,11 @@ public partial class Console : Node{
     public static void RemoveCvar(string cvarName) => console.Call("remove_cvar", cvarName);
     public static Variant GetCvar(string cvarName) => console.Call("get_cvar", cvarName);
     public static void SetCvar(string cvarName, Variant value) => console.Call("set_cvar", cvarName, value);
-    public static void AddCommandAutocompleteList(string commandName, string[] paramList) => console.Call("add_command_autocomplete_list", commandName, paramList);
+    public static void AddCommandAutocompleteList(string commandName, string[] paramList, int paramIndex = 1) => console.Call("add_command_autocomplete_list", commandName, paramList, paramIndex);
     public static void Disable() => console.Call("disable");
     public static void Enable() =>console.Call("enable");
     public static void ToggleConsole() => console.Call("toggle_console");
-    public static void IsVisible() => console.Call("is_visible");
+    public static bool IsVisible() => console.Call("is_visible").AsBool();
     public static void ScrollToBottom() => console.Call("scroll_to_bottom");
     public static void PrintError(Variant text, bool printGodot = false) => console.Call("print_error", text, printGodot);
     public static void PrintInfo(Variant text, bool printGodot = false) => console.Call("print_info", text, printGodot);


### PR DESCRIPTION
To add autocomplete for multiple parameters, call `Console.add_command_autocomplete_list(...)` multiple times with the `param_index` parameter set.

Closes #56
Also includes a bug fix in the C# bindings