### PR TITLE
Add a custom Logger class using OS.add_logger()

### DIFF
--- a/addons/console/console.gd
+++ b/addons/console/console.gd
@@ -417,6 +417,8 @@ func _exit_tree() -> void:
 		for pending_name in _pending_cvar_values:
 			if (!console_cvars.has(pending_name)):
 				console_cvars_file.store_line("%s %s" % [pending_name, var_to_str(_pending_cvar_values[pending_name])])
+	if is_instance_valid(logger):
+		OS.remove_logger(logger)
 
 
 func _ready() -> void:

--- a/addons/console/console.gd
+++ b/addons/console/console.gd
@@ -80,6 +80,40 @@ class ConsoleCvar:
 		else:
 			value = new_value
 
+class ConsoleLogger extends Logger:
+	func _log_error(function: String, file: String, line: int, code: String, rationale: String, editor_notify: bool, error_type: int, script_backtraces: Array[ScriptBacktrace]) -> void:
+		if is_instance_valid(Console):
+			var traces: String = ""
+			var time_string: String = Time.get_time_string_from_system()
+			for backtrace: ScriptBacktrace in script_backtraces:
+				for frame: int in backtrace.get_frame_count():
+					var frame_file: String = backtrace.get_frame_file(frame)
+					var frame_line: int = backtrace.get_frame_line(frame)
+					var frame_function: String = backtrace.get_frame_function(frame)
+					var language: String = backtrace.get_language_name()
+					## char(0x2022) is the bulletin character '•'
+					traces += "\t\t" + char(0x2022) + " %s:%d @ %s::%s() '%s' \n" % [frame_file, frame_line, language, frame_function, code]
+			
+			var message: String = str("%s\t\tError in Function " % time_string, " '%s' Line %d in file %s" % [function, line, file], " ", "\n\t\tScript Backtrace\n", traces)
+			match error_type:
+				ERROR_TYPE_ERROR:
+					if !ProjectSettings.get_setting("console/log_errors"): return
+					var color: String = color_dictionary.get(CONSOLE_COLOR_ERROR, Color.LIGHT_CORAL).to_html()
+					Console.print_line("\t\t[color=#%s]%s[/color]" % [color, message], false) 
+				
+				ERROR_TYPE_WARNING:
+					if !ProjectSettings.get_setting("console/log_warnings"): return
+					var color: String = color_dictionary.get(CONSOLE_COLOR_WARNING, Color.LIGHT_GOLDENROD).to_html()
+					message = str("%s\t\tWarning in Function " % time_string, " '%s' Line %d in file %s" % [function, line, file], " ", "\n\t\tScript Backtrace\n", traces)
+					Console.print_line("\t\t[color=#%s]%s[/color]" % [color, message], false) 
+				
+	
+	func _log_message(message: String, error: bool) -> void:
+		if is_instance_valid(Console):
+			if !ProjectSettings.get_setting("console/log_messages"): return
+			if error: Console.print_error(message, false)
+			else: Console.print_line(message)
+
 var theme : Theme
 var canvas_layer : CanvasLayer = CanvasLayer.new()
 var v_box_container : VBoxContainer = VBoxContainer.new()
@@ -101,6 +135,9 @@ var was_paused_already : bool = false
 
 var tab_string : String = "    "
 var text_block_cache : Array[String]
+
+var logger: ConsoleLogger
+
 
 ## Usage: Console.add_command("command_name", <function to call>, <number of arguments or array of argument names>, <required number of arguments>, "Help description")
 func add_command(command_name : String, function : Callable, arguments = [], required: int = 0, description : String = "") -> void:
@@ -308,6 +345,9 @@ func _enter_tree() -> void:
 	line_edit.text_changed.connect(_on_line_edit_text_changed)
 	v_box_container.visible = false
 	process_mode = PROCESS_MODE_ALWAYS
+	
+	logger = ConsoleLogger.new()
+	OS.add_logger(logger)
 
 
 ## Get the scale of the console from the settings -- if this is not in the system settings return a default value

--- a/addons/console/console_plugin.gd
+++ b/addons/console/console_plugin.gd
@@ -14,6 +14,11 @@ const CONSOLE_COLOR_LITERAL : String = &"console/color_literal"
 const CONSOLE_TABSTOP : String = &"console/tabstop"
 const CONSOLE_CANVAS_LAYER : String = &"console/canvas_layer"
 
+const CONSOLE_LOG_ERRORS : String = &"console/log_errors"
+const CONSOLE_LOG_MESSAGES: String = &"console/log_messages"
+const CONSOLE_LOG_WARNINGS: String = &"console/log_warnings"
+
+
 ##FIXME: This is here because project settings do no return the default value naturally
 ##This should be fixed in 4.5
 const color_dictionary : Dictionary[String, Color] = {
@@ -93,6 +98,22 @@ func _setup_project_settings() -> void:
 		"type": TYPE_COLOR,
 		"hint": PROPERTY_HINT_COLOR_NO_ALPHA
 	}, color_dictionary[CONSOLE_COLOR_LITERAL])
+
+	add_setting(CONSOLE_LOG_ERRORS, {
+		"name": CONSOLE_LOG_ERRORS,
+		"type": TYPE_BOOL,
+	}, false)
+
+	add_setting(CONSOLE_LOG_MESSAGES, {
+		"name": CONSOLE_LOG_MESSAGES,
+		"type": TYPE_BOOL,
+	}, false)
+
+	add_setting(CONSOLE_LOG_WARNINGS, {
+		"name": CONSOLE_LOG_WARNINGS,
+		"type": TYPE_BOOL,
+	}, false)
+
 
 	ProjectSettings.save()
 


### PR DESCRIPTION
This integrates a custom `Logger` class (was [added back in 4.5](https://godotengine.org/releases/4.5/#script-backtracing)) with related project settings to enable/disable different types of logging.

 At the moment it differentiates errors and warnings, as seen in this example:

<img width="620" height="250" alt="image" src="https://github.com/user-attachments/assets/dd7ac7cb-10e0-4d36-999d-64dd77395e79" />

it seems like godot can also give general script and shader errors to loggers as well, however i didn't feel like it was particularly needed since the backtrace gives enough information.