### PR TITLE
Add autocomplete ignore case setting

### DIFF
--- a/addons/console/console.gd
+++ b/addons/console/console.gd
@@ -12,6 +12,7 @@ const CONSOLE_CANVAS_LAYER : String = "console/canvas_layer"
 const CONSOLE_LOG_ERRORS : String = "console/log_errors"
 const CONSOLE_LOG_MESSAGES: String = "console/log_messages"
 const CONSOLE_LOG_WARNINGS: String = "console/log_warnings"
+const CONSOLE_AUTOCOMPLETE_IGNORE_CASE : String = "console/autocomplete_ignore_case"
 
 ##FIXME: This is here because project settings do no return the default value naturally
 ##This should be fixed in 4.5
@@ -137,6 +138,7 @@ var _pending_cvar_values : Dictionary[String, Variant] = {}
 # The key consists of the command name followed by a colon followed by the parameter index (starting at 1)
 # e.g.: "change_map:1" and "change_map:2"
 var command_parameters : Dictionary[String, PackedStringArray] = {}
+var autocomplete_ignore_case : bool = true
 var console_history : Array[String] = []
 var console_history_index : int = 0
 var was_paused_already : bool = false
@@ -238,6 +240,11 @@ static func setup_project_settings() -> void:
 		"name": CONSOLE_LOG_WARNINGS,
 		"type": TYPE_BOOL,
 	}, false)
+
+	_add_project_setting(CONSOLE_AUTOCOMPLETE_IGNORE_CASE, {
+		"name": CONSOLE_AUTOCOMPLETE_IGNORE_CASE,
+		"type": TYPE_BOOL,
+	}, true)
 
 	ProjectSettings.save()
 
@@ -389,9 +396,16 @@ func _handle_cvar(cvar : ConsoleCvar, arguments : PackedStringArray) -> void:
 	_print_cvar_value(cvar)
 
 
+## Returns a string that can be used as a dictionary key for command and parameter autocomplete
+func _get_command_autocomplete_key(command_name : String, param_index : int) -> String:
+	# We could do a .to_lower() here if we wanted even more autocomplete but that would break commands
+	# with mismatched case -- i.e. we have "AddMoney", "addmoney", and "addMoney" all defined
+	return "%s:%s" % [command_name, param_index]
+
+
 ## Useful if you have a list of possible parameters (ex: level names).
 func add_command_autocomplete_list(command_name : String, param_list : PackedStringArray, param_index: int = 1):
-	command_parameters["%s:%s"%[command_name,param_index]] = param_list
+	command_parameters[_get_command_autocomplete_key(command_name, param_index)] = param_list
 
 
 func _enter_tree() -> void:
@@ -421,6 +435,9 @@ func _enter_tree() -> void:
 		tab_string = ""
 		for i in range(ProjectSettings.get_setting(CONSOLE_TABSTOP)):
 			tab_string += " "
+
+	if ProjectSettings.has_setting(CONSOLE_AUTOCOMPLETE_IGNORE_CASE):
+		autocomplete_ignore_case = bool(ProjectSettings.get_setting(CONSOLE_AUTOCOMPLETE_IGNORE_CASE))
 
 	canvas_layer.layer = ProjectSettings.get_setting(CONSOLE_CANVAS_LAYER, 3)
 	add_child(canvas_layer)
@@ -610,56 +627,68 @@ func _input(event : InputEvent) -> void:
 					get_tree().get_root().set_input_as_handled()
 
 
+func is_autocomplete_match(input: String, param: String) -> bool:
+	return input.is_empty() or (param.containsn(input) if autocomplete_ignore_case else param.contains(input))
+
+
 var suggestions := []
 var current_suggest := 0
 var suggesting := false
 
 func autocomplete() -> void:
-	if (suggesting):
-		for i in range(suggestions.size()):
-			if (current_suggest == i):
-				line_edit.text = str(suggestions[i])
-				line_edit.caret_column = line_edit.text.length()
-				if (current_suggest == suggestions.size() - 1):
-					current_suggest = 0
-				else:
-					current_suggest += 1
-				return
+	if suggesting:
+		if suggestions:
+			current_suggest = mini(current_suggest, suggestions.size() - 1)
+			line_edit.text = str(suggestions[current_suggest])
+			line_edit.caret_column = line_edit.text.length()
+			current_suggest = wrapi(current_suggest + 1, 0, suggestions.size())
+		return
+
+	suggesting = true
+
+	if " " in line_edit.text:
+		var split_text: = parse_line_input(line_edit.text)
+		if split_text.size() > 1:
+			var param_index: = split_text.size() - 1
+			var input_command: = split_text[0]
+			var input_param: = split_text[param_index]
+			var autocomplete_key: = _get_command_autocomplete_key(input_command, param_index)
+
+			# We assume that input_command (and thus autocomplete_key) matches autocomplete key
+			# _exactly_ as we don't do a case insensitive search through the dictionary. It will be
+			# correct as long as we've either typed in the command name correctly or autocompleted
+			# the command name.
+			if command_parameters.has(autocomplete_key):
+				var ready_text: = " ".join(split_text.slice(0, -1))
+				for param: String in command_parameters[autocomplete_key]:
+					if is_autocomplete_match(input_param, param):
+						suggestions.append(str(ready_text, " ", param))
+
 	else:
-		suggesting = true
+		var query: = line_edit.text.strip_edges()
 
-		if (" " in line_edit.text): # We're searching for a parameter to autocomplete
-			var split_text := parse_line_input(line_edit.text)
-			if (split_text.size() > 1):
-				var param_index := split_text.size() - 1
-				var command := split_text[0]
-				var param_input := split_text[param_index]
-				var command_with_index := "%s:%s"%[command,param_index]
-				if (command_parameters.has(command_with_index)):
-					var ready_text := " ".join(split_text.slice(0,-1))
-					for param in command_parameters[command_with_index]:
-						if (param_input in param) or (param_input.length() == 0):
-							suggestions.append(str(ready_text, " ", param))
-		else:
-			var sorted_commands := []
-			for command in console_commands:
-				if (!console_commands[command].hidden):
-					sorted_commands.append(str(command))
-			for cvar_name in console_cvars:
-				sorted_commands.append(str(cvar_name))
-			sorted_commands.sort()
-			sorted_commands.reverse()
+		var matches: Array[String] = []
+		for command_name: String in console_commands:
+			if console_commands[command_name].hidden:
+				continue
+			if is_autocomplete_match(query, command_name):
+				matches.append(command_name)
+		for cvar_name: String in console_cvars:
+			if is_autocomplete_match(query, cvar_name):
+				matches.append(cvar_name)
 
-			var prev_index := 0
-			for command in sorted_commands:
-				if (!line_edit.text || command.contains(line_edit.text)):
-					var index : int = command.find(line_edit.text)
-					if (index <= prev_index):
-						suggestions.push_front(command)
-					else:
-						suggestions.push_back(command)
-					prev_index = index
-		autocomplete()
+		matches.sort_custom(func (a: String, b: String) -> bool:
+			var ai: = a.findn(query) if autocomplete_ignore_case else a.find(query)
+			var bi: = b.findn(query) if autocomplete_ignore_case else b.find(query)
+			if ai != bi:
+				return ai < bi
+			var cmp: = a.naturalnocasecmp_to(b) if autocomplete_ignore_case else a.naturalcasecmp_to(b)
+			return cmp < 0
+		)
+
+		suggestions = matches
+
+	autocomplete()
 
 
 func reset_autocomplete() -> void:

--- a/addons/console/console.gd
+++ b/addons/console/console.gd
@@ -1,15 +1,20 @@
 extends Node
 
-const CONSOLE_THEME : String = &"console/theme"
-const CONSOLE_SCALE : String = &"console/scale"
-const CONSOLE_HEIGHT : String = &"console/height"
-const CONSOLE_COLOR_WARNING : String = &"console/color_warning"
-const CONSOLE_COLOR_ERROR : String = &"console/color_error"
-const CONSOLE_COLOR_INFO : String = &"console/color_info"
-const CONSOLE_COLOR_LITERAL : String = &"console/color_literal"
-const CONSOLE_TABSTOP : String = &"console/tabstop"
-const CONSOLE_CANVAS_LAYER : String = &"console/canvas_layer"
+const CONSOLE_THEME : String = "console/theme"
+const CONSOLE_SCALE : String = "console/scale"
+const CONSOLE_HEIGHT : String = "console/height"
+const CONSOLE_COLOR_WARNING : String = "console/color_warning"
+const CONSOLE_COLOR_ERROR : String = "console/color_error"
+const CONSOLE_COLOR_INFO : String = "console/color_info"
+const CONSOLE_COLOR_LITERAL : String = "console/color_literal"
+const CONSOLE_TABSTOP : String = "console/tabstop"
+const CONSOLE_CANVAS_LAYER : String = "console/canvas_layer"
+const CONSOLE_LOG_ERRORS : String = "console/log_errors"
+const CONSOLE_LOG_MESSAGES: String = "console/log_messages"
+const CONSOLE_LOG_WARNINGS: String = "console/log_warnings"
 
+##FIXME: This is here because project settings do no return the default value naturally
+##This should be fixed in 4.5
 const color_dictionary : Dictionary[String, Color] = {
 	CONSOLE_COLOR_ERROR: Color.LIGHT_CORAL,
 	CONSOLE_COLOR_INFO: Color.LIGHT_BLUE,
@@ -98,12 +103,12 @@ class ConsoleLogger extends Logger:
 			var message: String = str("%s\t\tError in Function " % time_string, " '%s' Line %d in file %s" % [function, line, file], " ", "\n\t\tScript Backtrace\n", traces)
 			match error_type:
 				ERROR_TYPE_ERROR:
-					if !ProjectSettings.get_setting("console/log_errors"): return
+					if !ProjectSettings.get_setting(CONSOLE_LOG_ERRORS): return
 					var color: String = color_dictionary.get(CONSOLE_COLOR_ERROR, Color.LIGHT_CORAL).to_html()
 					Console.print_line("\t\t[color=#%s]%s[/color]" % [color, message], false) 
 				
 				ERROR_TYPE_WARNING:
-					if !ProjectSettings.get_setting("console/log_warnings"): return
+					if !ProjectSettings.get_setting(CONSOLE_LOG_WARNINGS): return
 					var color: String = color_dictionary.get(CONSOLE_COLOR_WARNING, Color.LIGHT_GOLDENROD).to_html()
 					message = str("%s\t\tWarning in Function " % time_string, " '%s' Line %d in file %s" % [function, line, file], " ", "\n\t\tScript Backtrace\n", traces)
 					Console.print_line("\t\t[color=#%s]%s[/color]" % [color, message], false) 
@@ -111,7 +116,7 @@ class ConsoleLogger extends Logger:
 	
 	func _log_message(message: String, error: bool) -> void:
 		if is_instance_valid(Console):
-			if !ProjectSettings.get_setting("console/log_messages"): return
+			if !ProjectSettings.get_setting(CONSOLE_LOG_MESSAGES): return
 			if error: Console.print_error(message, false)
 			else: Console.print_line(message)
 
@@ -140,6 +145,101 @@ var tab_string : String = "    "
 var text_block_cache : Array[String]
 
 var logger: ConsoleLogger
+
+## Should only be called during plugin initialization
+static func _add_project_setting(setting_name: String, property_info: Dictionary, default: Variant) -> void:
+	if not ProjectSettings.has_setting(setting_name):
+		ProjectSettings.set_setting(setting_name, default)
+	ProjectSettings.add_property_info(property_info)
+	ProjectSettings.set_initial_value(setting_name, default)
+	ProjectSettings.set_as_basic(setting_name, true)
+
+
+## Should only be called during plugin initialization
+## Will be called by the EditorPlugin in this addon
+static func setup_project_settings() -> void:
+	if not Engine.is_editor_hint():
+		return
+
+	## Configure Console Theme
+	_add_project_setting(CONSOLE_THEME, {
+		"name": CONSOLE_THEME,
+		"type": TYPE_STRING,
+		"hint": PROPERTY_HINT_FILE,
+		"hint_string": "*.tres",
+	}, "")
+
+	## Configure Console Scale
+	_add_project_setting(CONSOLE_SCALE, {
+		"name": CONSOLE_SCALE,
+		"type": TYPE_FLOAT,
+		"hint": PROPERTY_HINT_RANGE,
+		"hint_string": "0,10,0.1,or_greater"
+	}, 1.0)
+
+	## Configure Console Height
+	_add_project_setting(CONSOLE_HEIGHT, {
+		"name": CONSOLE_HEIGHT,
+		"type": TYPE_FLOAT,
+		"hint": PROPERTY_HINT_RANGE,
+		"hint_string": "0,1,0.1"
+	}, 0.5)
+
+	## Configure Tab Spaces
+	_add_project_setting(CONSOLE_TABSTOP, {
+		"name": CONSOLE_TABSTOP,
+		"type": TYPE_INT,
+		"hint": PROPERTY_HINT_RANGE,
+		"hint_string": "0,8,1,or_greater"
+	},4)
+
+	## Configure Canvas Layer
+	_add_project_setting(CONSOLE_CANVAS_LAYER, {
+		"name": CONSOLE_CANVAS_LAYER,
+		"type": TYPE_INT,
+	}, 3)
+
+	#Configure Colors
+	_add_project_setting(CONSOLE_COLOR_ERROR, {
+		"name": CONSOLE_COLOR_ERROR,
+		"type": TYPE_COLOR,
+		"hint": PROPERTY_HINT_COLOR_NO_ALPHA,
+	}, color_dictionary[CONSOLE_COLOR_ERROR])
+
+	_add_project_setting(CONSOLE_COLOR_INFO, {
+		"name": CONSOLE_COLOR_INFO,
+		"type": TYPE_COLOR,
+		"hint": PROPERTY_HINT_COLOR_NO_ALPHA,
+	}, color_dictionary[CONSOLE_COLOR_INFO])
+
+	_add_project_setting(CONSOLE_COLOR_WARNING, {
+		"name": CONSOLE_COLOR_WARNING,
+		"type": TYPE_COLOR,
+		"hint": PROPERTY_HINT_COLOR_NO_ALPHA,
+	}, color_dictionary[CONSOLE_COLOR_WARNING])
+
+	_add_project_setting(CONSOLE_COLOR_LITERAL, {
+		"name": CONSOLE_COLOR_LITERAL,
+		"type": TYPE_COLOR,
+		"hint": PROPERTY_HINT_COLOR_NO_ALPHA
+	}, color_dictionary[CONSOLE_COLOR_LITERAL])
+
+	_add_project_setting(CONSOLE_LOG_ERRORS, {
+		"name": CONSOLE_LOG_ERRORS,
+		"type": TYPE_BOOL,
+	}, false)
+
+	_add_project_setting(CONSOLE_LOG_MESSAGES, {
+		"name": CONSOLE_LOG_MESSAGES,
+		"type": TYPE_BOOL,
+	}, false)
+
+	_add_project_setting(CONSOLE_LOG_WARNINGS, {
+		"name": CONSOLE_LOG_WARNINGS,
+		"type": TYPE_BOOL,
+	}, false)
+
+	ProjectSettings.save()
 
 
 ## Usage: Console.add_command("command_name", <function to call>, <number of arguments or array of argument names>, <required number of arguments>, "Help description")

--- a/addons/console/console.gd
+++ b/addons/console/console.gd
@@ -8,6 +8,7 @@ const CONSOLE_COLOR_ERROR : String = &"console/color_error"
 const CONSOLE_COLOR_INFO : String = &"console/color_info"
 const CONSOLE_COLOR_LITERAL : String = &"console/color_literal"
 const CONSOLE_TABSTOP : String = &"console/tabstop"
+const CONSOLE_CANVAS_LAYER : String = &"console/canvas_layer"
 
 const color_dictionary : Dictionary[String, Color] = {
 	CONSOLE_COLOR_ERROR: Color.LIGHT_CORAL,
@@ -321,7 +322,7 @@ func _enter_tree() -> void:
 		for i in range(ProjectSettings.get_setting(CONSOLE_TABSTOP)):
 			tab_string += " "
 
-	canvas_layer.layer = ProjectSettings.get_setting(&"console/canvas_layer", 3)
+	canvas_layer.layer = ProjectSettings.get_setting(CONSOLE_CANVAS_LAYER, 3)
 	add_child(canvas_layer)
 	console_scale = _get_console_scale_setting()
 	v_box_container.offset_bottom = 0

--- a/addons/console/console_plugin.gd
+++ b/addons/console/console_plugin.gd
@@ -1,126 +1,19 @@
 @tool
 extends EditorPlugin
 
-const SINGLETON_NAME = &"Console"
 
-##FIXME: These should be maintained in one place.
-const CONSOLE_THEME : String = &"console/theme"
-const CONSOLE_SCALE : String = &"console/scale"
-const CONSOLE_HEIGHT : String = &"console/height"
-const CONSOLE_COLOR_WARNING : String = &"console/color_warning"
-const CONSOLE_COLOR_ERROR : String = &"console/color_error"
-const CONSOLE_COLOR_INFO : String = &"console/color_info"
-const CONSOLE_COLOR_LITERAL : String = &"console/color_literal"
-const CONSOLE_TABSTOP : String = &"console/tabstop"
-const CONSOLE_CANVAS_LAYER : String = &"console/canvas_layer"
-
-const CONSOLE_LOG_ERRORS : String = &"console/log_errors"
-const CONSOLE_LOG_MESSAGES: String = &"console/log_messages"
-const CONSOLE_LOG_WARNINGS: String = &"console/log_warnings"
+const SINGLETON_NAME: = "Console"
+const CONSOLE_SCRIPT: = "res://addons/console/console.gd"
 
 
-##FIXME: This is here because project settings do no return the default value naturally
-##This should be fixed in 4.5
-const color_dictionary : Dictionary[String, Color] = {
-	CONSOLE_COLOR_ERROR: Color.LIGHT_CORAL,
-	CONSOLE_COLOR_INFO: Color.LIGHT_BLUE,
-	CONSOLE_COLOR_LITERAL: Color.PALE_GREEN,
-	CONSOLE_COLOR_WARNING: Color.LIGHT_GOLDENROD
-}
-
-func add_setting(setting_name: String, property_info: Dictionary, default: Variant) -> void:
-	if not ProjectSettings.has_setting(setting_name):
-		ProjectSettings.set_setting(setting_name, default)
-	ProjectSettings.add_property_info(property_info)
-	ProjectSettings.set_initial_value(setting_name, default)
-	ProjectSettings.set_as_basic(setting_name, true)
-
-func _setup_project_settings() -> void:
-	## Configure Console Theme
-	add_setting(CONSOLE_THEME, {
-		"name": CONSOLE_THEME,
-		"type": TYPE_STRING,
-		"hint": PROPERTY_HINT_FILE,
-		"hint_string": "*.tres",
-	}, "")
-
-	## Configure Console Scale
-	add_setting(CONSOLE_SCALE, {
-		"name": CONSOLE_SCALE,
-		"type": TYPE_FLOAT,
-		"hint": PROPERTY_HINT_RANGE,
-		"hint_string": "0,10,0.1,or_greater"
-	}, 1.0)
-
-	## Configure Console Height
-	add_setting(CONSOLE_HEIGHT, {
-		"name": CONSOLE_HEIGHT,
-		"type": TYPE_FLOAT,
-		"hint": PROPERTY_HINT_RANGE,
-		"hint_string": "0,1,0.1"
-	}, 0.5)
-
-	## Configure Tab Spaces
-	add_setting(CONSOLE_TABSTOP, {
-		"name": CONSOLE_TABSTOP,
-		"type": TYPE_INT,
-		"hint": PROPERTY_HINT_RANGE,
-		"hint_string": "0,8,1,or_greater"
-	},4)
-
-	## Configure Canvas Layer
-	add_setting(CONSOLE_CANVAS_LAYER, {
-		"name": CONSOLE_CANVAS_LAYER,
-		"type": TYPE_INT,
-	}, 3)
-
-	#Configure Colors
-	add_setting(CONSOLE_COLOR_ERROR, {
-		"name": CONSOLE_COLOR_ERROR,
-		"type": TYPE_COLOR,
-		"hint": PROPERTY_HINT_COLOR_NO_ALPHA,
-	}, color_dictionary[CONSOLE_COLOR_ERROR])
-
-	add_setting(CONSOLE_COLOR_INFO, {
-		"name": CONSOLE_COLOR_INFO,
-		"type": TYPE_COLOR,
-		"hint": PROPERTY_HINT_COLOR_NO_ALPHA,
-	}, color_dictionary[CONSOLE_COLOR_INFO])
-
-	add_setting(CONSOLE_COLOR_WARNING, {
-		"name": CONSOLE_COLOR_WARNING,
-		"type": TYPE_COLOR,
-		"hint": PROPERTY_HINT_COLOR_NO_ALPHA,
-	}, color_dictionary[CONSOLE_COLOR_WARNING])
-
-	add_setting(CONSOLE_COLOR_LITERAL, {
-		"name": CONSOLE_COLOR_LITERAL,
-		"type": TYPE_COLOR,
-		"hint": PROPERTY_HINT_COLOR_NO_ALPHA
-	}, color_dictionary[CONSOLE_COLOR_LITERAL])
-
-	add_setting(CONSOLE_LOG_ERRORS, {
-		"name": CONSOLE_LOG_ERRORS,
-		"type": TYPE_BOOL,
-	}, false)
-
-	add_setting(CONSOLE_LOG_MESSAGES, {
-		"name": CONSOLE_LOG_MESSAGES,
-		"type": TYPE_BOOL,
-	}, false)
-
-	add_setting(CONSOLE_LOG_WARNINGS, {
-		"name": CONSOLE_LOG_WARNINGS,
-		"type": TYPE_BOOL,
-	}, false)
-
-
-	ProjectSettings.save()
+func _enter_tree() -> void:
+	# Initialize project settings when plugin is started
+	# Ensures that we see all the settings in the editor
+	preload(CONSOLE_SCRIPT).setup_project_settings()
 
 
 func _enable_plugin() -> void:
-	add_autoload_singleton(SINGLETON_NAME, "res://addons/console/console.gd")
-	_setup_project_settings()
+	add_autoload_singleton(SINGLETON_NAME, CONSOLE_SCRIPT)
 	print("Console plugin enabled.")
 
 


### PR DESCRIPTION
This PR reworks project settings and adds a setting to toggle case sensitive autocomplete on and off.

* ~**WARNING: Breaking change!** All settings are renamed from `console/*` to `console/settings/*` so that they show up in a "Console" group in Project Settings~
* Project settings are defined in one place: `console.gd` which fixes duplication in `console_plugin.gd`
* Project settings are registered and set up when plugin is activated
* Added missing canvas layer setting constant in `console.gd`
* Autocomplete routine reworked adding minor optimizations and improvements
* Autocomplete is implemented as non-intrusively as possible (see comments in code)

As usual, feel free to ignore this PR if it's not interesting. Just figured I'd share my little tweaks. :) I've been running this for a bit but some testing might be needed.

Edit 1: Fixed regression in autocomplete behavior (fixed positional autocomplete + changed `begins_with()` back to `contains()` again)
Edit 2: Fixed minor code smell by using `assign()` on typed array rather than `=` to preserve type
Edit 3: Fixed typo in comment
Edit 4: Updated branch with new logger changes
Edit 5: Fixed regression introduced by branch merge
Edit 6: Minor improvement to the autocomplete code
Edit 7: Ignore case is on by default, removed settings rename/grouping, and some minor fixes